### PR TITLE
Add a useful error message to unknown party in query

### DIFF
--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -26,6 +26,6 @@ def test_unified(api_reader: UNFCCCApiReader):
     ans = api_reader.query(party_code="DEU", gases=["N₂O"])
     assert len(ans) > 1
 
-    match = 'Unknown party *'
+    match = "Unknown party *"
     with pytest.raises(ValueError, match=match):
         api_reader.query(party_code="ASDF")

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -25,5 +25,7 @@ def test_unified(api_reader: UNFCCCApiReader):
     assert len(ans) > 1
     ans = api_reader.query(party_code="DEU", gases=["N₂O"])
     assert len(ans) > 1
-    with pytest.raises(KeyError):
+
+    match = 'Unknown party *'
+    with pytest.raises(ValueError, match=match):
         api_reader.query(party_code="ASDF")

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -102,7 +102,8 @@ class UNFCCCApiReader:
         elif party_code in self.non_annex_one_reader.parties["code"].values:
             reader = self.non_annex_one_reader
         else:
-            raise KeyError(party_code)
+            help = 'try `UNFCCCApiReader().parties` for list of valid codes'
+            raise ValueError(f'Unknown party `{party_code}`, {help}!')
 
         return reader.query(party_codes=[party_code], gases=gases, progress=progress)
 

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -102,8 +102,8 @@ class UNFCCCApiReader:
         elif party_code in self.non_annex_one_reader.parties["code"].values:
             reader = self.non_annex_one_reader
         else:
-            help = 'try `UNFCCCApiReader().parties` for list of valid codes'
-            raise ValueError(f'Unknown party `{party_code}`, {help}!')
+            help = "try `UNFCCCApiReader().parties` for list of valid codes"
+            raise ValueError(f"Unknown party `{party_code}`, {help}!")
 
         return reader.query(party_codes=[party_code], gases=gases, progress=progress)
 


### PR DESCRIPTION
This PR adds a useful error message when querying data for an unknown party (including a hint where to find the right info). Also, the error type is changed from `KeyError` to `ValueError` because from the point-of-view of the user, party is an input value for the function (internally, it's the key in a table, but I think the user perspective should have priority).