### PR TITLE
Accept and return (optional) ASCII format for gases and units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Next release
+------------
+
+* Accept ASCII format for `gases` when querying data
+  and return gases & units normalized to ASCII (optional).
+
 1.1.1 (2021-02-08)
 ------------------
 

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -34,3 +34,9 @@ def test_unified(api_reader: UNFCCCApiReader):
     match = "Unknown party *"
     with pytest.raises(ValueError, match=match):
         api_reader.query(party_code="ASDF")
+
+
+def test_unified_as_ascii(api_reader: UNFCCCApiReader):
+    # assert that using standardized string ('N2O' instead of "N₂O") works
+    ans = api_reader.query(party_code="DEU", gases=["N2O"])
+    assert len(ans) > 1

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -36,7 +36,10 @@ def test_unified(api_reader: UNFCCCApiReader):
         api_reader.query(party_code="ASDF")
 
 
-def test_unified_as_ascii(api_reader: UNFCCCApiReader):
+@pytest.mark.parametrize("normalize", [True, False])
+def test_unified_as_ascii(api_reader: UNFCCCApiReader, normalize: bool):
     # assert that using standardized string ('N2O' instead of "N₂O") works
-    ans = api_reader.query(party_code="DEU", gases=["N2O"])
+    ans = api_reader.query(party_code="DEU", gases=["N2O"],
+                           normalize_gas_names=normalize)
     assert len(ans) > 1
+    assert ans.gas.unique()[0] == ("N2O" if normalize else "N₂O")

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -39,7 +39,8 @@ def test_unified(api_reader: UNFCCCApiReader):
 @pytest.mark.parametrize("normalize", [True, False])
 def test_unified_as_ascii(api_reader: UNFCCCApiReader, normalize: bool):
     # assert that using standardized string ('N2O' instead of "N₂O") works
-    ans = api_reader.query(party_code="DEU", gases=["N2O"],
-                           normalize_gas_names=normalize)
+    ans = api_reader.query(
+        party_code="DEU", gases=["N2O"], normalize_gas_names=normalize
+    )
     assert len(ans) > 1
     assert ans.gas.unique()[0] == ("N2O" if normalize else "N₂O")

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -44,8 +44,8 @@ GAS_MAPPING = {
 }
 
 # mapping of subscript notation to ASCII string
-NORMALSCRIPT = '0123456789x'
-SUBSCRIPT = '₀₁₂₃₄₅₆₇₈₉ₓ'
+NORMALSCRIPT = "0123456789x"
+SUBSCRIPT = "₀₁₂₃₄₅₆₇₈₉ₓ"
 MAKE_ASCII = str.maketrans(SUBSCRIPT, NORMALSCRIPT)
 
 

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -24,23 +24,23 @@ import treelib
 
 # mapping from gas as simple string to subscript-format used by UNFCCC DI API
 GAS_MAPPING = {
-    'CH4': 'CH₄',
-    'CO2': 'CO₂',
-    'N2O': 'N₂O',
-    'NF3': 'NF₃',
-    'SF6': 'SF₆',
-    'CF4': 'CF₄',
-    'C2F6': 'C₂F₆',
-    'c-C3F6': 'c-C₃F₆',
-    'C3F8': 'C₃F₈',
-    'c-C4F8': 'c-C₄F₈',
-    'C4F10': 'C₄F₁₀',
-    'C5F12': 'C5F₁₂',  # this seems to be a typo in the UNFCCC API
-    'C6F14': 'C₆F₁₄',
-    'C10F18': 'C₁₀F₁₈',
-    'NH3': 'NH₃',
-    'NOx': 'NOₓ',
-    'SO2': 'SO₂'
+    "CH4": "CH₄",
+    "CO2": "CO₂",
+    "N2O": "N₂O",
+    "NF3": "NF₃",
+    "SF6": "SF₆",
+    "CF4": "CF₄",
+    "C2F6": "C₂F₆",
+    "c-C3F6": "c-C₃F₆",
+    "C3F8": "C₃F₈",
+    "c-C4F8": "c-C₄F₈",
+    "C4F10": "C₄F₁₀",
+    "C5F12": "C5F₁₂",  # this seems to be a typo in the UNFCCC API
+    "C6F14": "C₆F₁₄",
+    "C10F18": "C₁₀F₁₈",
+    "NH3": "NH₃",
+    "NOx": "NOₓ",
+    "SO2": "SO₂",
 }
 
 # mapping of subscript notation to ASCII string
@@ -148,7 +148,6 @@ class UNFCCCApiReader:
                 data[c] = data[c].apply(lambda x: x.translate(MAKE_ASCII))
 
         return data
-
 
 
 class UNFCCCSingleCategoryApiReader:

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -22,6 +22,27 @@ import pandas as pd
 import requests
 import treelib
 
+# mapping from gas as simple string to subscript-format used by UNFCCC DI API
+GAS_MAPPING = {
+    'CH4': 'CH₄',
+    'CO2': 'CO₂',
+    'N2O': 'N₂O',
+    'NF3': 'NF₃',
+    'SF6': 'SF₆',
+    'CF4': 'CF₄',
+    'C2F6': 'C₂F₆',
+    'c-C3F6': 'c-C₃F₆',
+    'C3F8': 'C₃F₈',
+    'c-C4F8': 'c-C₄F₈',
+    'C4F10': 'C₄F₁₀',
+    'C5F12': 'C5F₁₂',  # this seems to be a typo in the UNFCCC API
+    'C6F14': 'C₆F₁₄',
+    'C10F18': 'C₁₀F₁₈',
+    'NH3': 'NH₃',
+    'NOx': 'NOₓ',
+    'SO2': 'SO₂'
+}
+
 
 class UNFCCCApiReader:
     """Provides simplified unified access to the Flexible Query API of the UNFCCC data
@@ -81,7 +102,8 @@ class UNFCCCApiReader:
             :py:attr:`~UNFCCCApiReader.parties`.
         gases : list of str, optional
             Limit the query to these gases. For possible values, see
-            :py:attr:`~UNFCCCApiReader.gases`. Default: query for all gases.
+            :py:attr:`~UNFCCCApiReader.gases`. Accepts subscripts ("N₂O")
+            as well as ASCII-strings ("N2O"). Default: query for all gases.
         progress : bool
             Display a progress bar. Requires the :py:mod:`tqdm` library. Default: false.
 
@@ -97,6 +119,11 @@ class UNFCCCApiReader:
         corresponding methods :py:meth:`UNFCCCApiReader.annex_one_reader.query` and
         :py:meth:`UNFCCCApiReader.non_annex_one_reader.query`.
         """
+        # format gases to subscript notation
+        if gases is not None:
+            gases = [GAS_MAPPING.get(g, g) for g in gases]
+
+        # select corresponding reader
         if party_code in self.annex_one_reader.parties["code"].values:
             reader = self.annex_one_reader
         elif party_code in self.non_annex_one_reader.parties["code"].values:

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -141,11 +141,10 @@ class UNFCCCApiReader:
             help = "try `UNFCCCApiReader().parties` for a list of valid codes"
             raise ValueError(f"Unknown party `{party_code}`, {help}!")
 
-        data = reader.query(party_codes=[party_code], gases=gases,
-                            progress=progress)
+        data = reader.query(party_codes=[party_code], gases=gases, progress=progress)
 
         if normalize_gas_names:
-            for c in ['unit', 'gas']:
+            for c in ["unit", "gas"]:
                 data[c] = data[c].apply(lambda x: x.translate(MAKE_ASCII))
 
         return data


### PR DESCRIPTION
This PR brings in a generalization of the API, per a comment by @mikapfl, see https://github.com/IAMconsortium/pyam/pull/497#issuecomment-775301134.

The `UNFCCCApiReader.query()´ now accepts simple ASCII-strings of gases (N2O instead of N₂O), and optionally (default) returns the gases and unit columns normalized to ASCII.

*Note*: Not sure if 'C5F₁₂' in the UNFCCC API is a bug or a feature, but I figured that the explicit dictionary is preferable (more readable) to a "make everything subscript except for ..." function.