### PR TITLE
NoDataError on empty query results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Unreleased
 ----------
 
 * Fix pre-commit config for newer mypy type checking versions.
+* Raise a more informative NoDataError (subclass of KeyError) instead of a generic
+  KeyError when a query result is empty.
 
 2.0.1 (2021-04-23)
 ------------------

--- a/unfccc_di_api/__init__.py
+++ b/unfccc_di_api/__init__.py
@@ -12,6 +12,6 @@ __author__ = """Mika Pflüger"""
 __email__ = "mika.pflueger@pik-potsdam.de"
 __version__ = "2.0.1"
 
-from .unfccc_di_api import UNFCCCApiReader, UNFCCCSingleCategoryApiReader
+from .unfccc_di_api import NoDataError, UNFCCCApiReader, UNFCCCSingleCategoryApiReader
 
-__all__ = ["UNFCCCApiReader", "UNFCCCSingleCategoryApiReader"]
+__all__ = ["UNFCCCApiReader", "UNFCCCSingleCategoryApiReader", "NoDataError"]

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import unfccc_di_api
 from unfccc_di_api import UNFCCCApiReader
 
 
@@ -44,3 +45,8 @@ def test_unified_as_ascii(api_reader: UNFCCCApiReader, normalize: bool):
     )
     assert len(ans) > 1
     assert ans.gas.unique()[0] == ("N2O" if normalize else "N₂O")
+
+
+def test_no_data(api_reader: UNFCCCApiReader):
+    with pytest.raises(unfccc_di_api.NoDataError):
+        api_reader.annex_one_reader.query(party_codes=["FIN"], category_ids=[14817])

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -49,6 +49,15 @@ SUBSCRIPT = "₀₁₂₃₄₅₆₇₈₉ₓ"
 MAKE_ASCII = str.maketrans(SUBSCRIPT, NORMALSCRIPT)
 
 
+class NoDataError(KeyError):
+    """Query returned no data"""
+
+    def __init__(
+        self,
+    ):
+        KeyError.__init__(self, "")  # TODO
+
+
 class UNFCCCApiReader:
     """Provides simplified unified access to the Flexible Query API of the UNFCCC data
     access for all parties.

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -50,12 +50,26 @@ MAKE_ASCII = str.maketrans(SUBSCRIPT, NORMALSCRIPT)
 
 
 class NoDataError(KeyError):
-    """Query returned no data"""
+    """Query returned no data."""
 
     def __init__(
         self,
+        party_codes: typing.Sequence[str],
+        category_ids: typing.Optional[typing.Sequence[int]] = None,
+        classifications: typing.Optional[typing.Sequence[str]] = None,
+        measure_ids: typing.Optional[typing.Sequence[int]] = None,
+        gases: typing.Optional[typing.Sequence[str]] = None,
     ):
-        KeyError.__init__(self, "")  # TODO
+        query = f"party_codes={party_codes!r}"
+        for optional_param, key in (
+            (category_ids, "category_ids"),
+            (classifications, "classifications"),
+            (measure_ids, "measure_ids"),
+            (gases, "gases"),
+        ):
+            if optional_param is not None:
+                query += f" {key}={optional_param!r}"
+        KeyError.__init__(self, f"Query returned no data for: {query}")
 
 
 class UNFCCCApiReader:
@@ -398,6 +412,15 @@ transparency-and-reporting/greenhouse-gas-data/data-interface-help#eq-7
 
         if progress:
             pbar.close()
+
+        if not raw_response:
+            raise NoDataError(
+                party_codes=party_codes,
+                category_ids=category_ids,
+                classifications=classifications,
+                measure_ids=measure_ids,
+                gases=gases,
+            )
 
         df = self._parse_raw_answer(raw_response)
 


### PR DESCRIPTION
Closes #29 by raising a more informative NoDataError (subclass of KeyError) instead of letting a rather uninformative KeyError bubble up.