### PR TITLE
Handle newly introduced unknown measures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Fix handling of unspecified measure IDs. The DI API started returning measure IDs
+  without a name or description. We now call them ``unknown measure nr. {measureId}``
+  instead of erroring out.
+
 3.0.0 (2021-12-03)
 ------------------
 

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -479,13 +479,18 @@ transparency-and-reporting/greenhouse-gas-data/data-interface-help#eq-7
                 except treelib.tree.NodeIDAbsentError:
                     category = f'unknown category nr. {variable["categoryId"]}'
 
+                try:
+                    measure = self.measure_tree[variable["measureId"]].tag
+                except treelib.tree.NodeIDAbsentError:
+                    measure = f'unknown measure nr. {variable["measureId"]}'
+
                 row = {
                     "party": self._parties_dict[dp["partyId"]],
                     "category": category,
                     "classification": self._classifications_dict[
                         variable["classificationId"]
                     ],
-                    "measure": self.measure_tree[variable["measureId"]].tag,
+                    "measure": measure,
                     "gas": self._gases_dict[variable["gasId"]],
                     "unit": self._units_dict[variable["unitId"]],
                     "year": self._years_dict[dp["yearId"]],


### PR DESCRIPTION
The DI API introduced unspecified measures! Previously, we already had unspecified categories, but now we also get unspecified measures. We handle them like we handle unspecified categories, by calling them `unknown measure nr. {measureId}`. Fixes: #37 