### PR TITLE
feat: add ZenodoReader which doesn't rely on the UNFCCC Api

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,11 +1,11 @@
 Developers
 ----------
 
-* Mika Pflüger `<mika.pflueger@pik-potsdam.de>`_
+* Mika Pflüger `<mika.pflueger@climate-resource.com>`_
 
 Contributors
 ------------
 
 * Florian Dierickx `<floriandierickx.github.io>`_
 * Daniel Huppmann `<https://twitter.com/daniel_huppmann>`_
-* Johannes Gütschow <johannes.guetschow@pik-potsdam.de>
+* Johannes Gütschow <johannes.guetschow@climate-resource.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 * Breaking: the UNFCCC restricted API access, likely you have to change your code to
   use the new ZenodoReader instead.
 * Add ZenodoReader which doesn't rely on API access.
+* Use data released until 2023-07-18 when using the ZenodoReader.
 * Build the documentation on ReadTheDocs using newer Python and Sphinx versions.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Breaking: the UNFCCC restricted API access, likely you have to change your code to
+  use the new ZenodoReader instead.
+* Add ZenodoReader which doesn't rely on API access.
 * Build the documentation on ReadTheDocs using newer Python and Sphinx versions.
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Apache Software License 2.0
 
 Copyright 2020-2021 Potsdam-Institut für Klimafolgenforschung e.V.
+Copyright 2023 Climate Resource Pty Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Warning
 Due to a recent change in the UNFCCC's API, the UNFCCCApiReader class is
 **not functional** any more in standard environments. To continue to access the data,
 you have two options:
+
 1. Use the new ZenodoReader. It provides access using the `query` function like the
    UNFCCCApiReader, but only supports querying for a full dataset with all data. It
    relies on our `data package <https://doi.org/10.5281/zenodo.4198782>`_, which we

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,17 @@ the UNFCCC.
 Warning
 -------
 
-Due to a recent change in the UNFCCC's API, this package is **not** functional
-anymore. We are looking for a fix, but can't promise anything.
+Due to a recent change in the UNFCCC's API, the UNFCCCApiReader class is
+**not functional** any more in standard environments. To continue to access the data,
+you have two options:
+1. Use the new ZenodoReader. It provides access using the `query` function like the
+   UNFCCCApiReader, but only supports querying for a full dataset with all data. It
+   relies on our `data package <https://doi.org/10.5281/zenodo.4198782>`_, which we
+   update regularly; however, the data is naturally not as recent as querying from
+   the API directly.
+2. Run your functions in an environment which is not blocked by the UNFCCC DI API.
+   According to our tests, Azure virtual machines work, as well as github hosted
+   runners, with the exception of Mac OS runners.
 
 
 Features

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -10,8 +10,8 @@
    "source": [
     "# Usage\n",
     "\n",
-    "To use the UNFCCC API, import the package and instantiate the reader,\n",
-    "which will download the most recent metadata from the UNFCCC:"
+    "To download the data from Zenodo, import the package and instantiate the reader,\n",
+    "which will download the most recent dataset:"
    ]
   },
   {
@@ -30,7 +30,7 @@
    "source": [
     "import unfccc_di_api\n",
     "\n",
-    "reader = unfccc_di_api.UNFCCCApiReader()"
+    "reader = unfccc_di_api.ZenodoReader()"
    ]
   },
   {
@@ -97,36 +97,9 @@
     }
    },
    "source": [
-    "Queries can be more specific, e.g. selecting only data about one gas:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "reader.query(party_code=\"DEU\", gases=[\"N₂O\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "Queries can be made much more specific, if you want to. Check the API\n",
-    "docs section (next section), or the docstrings for details."
+    "You can also request data directly form the UNFCCC DI API if you have a way to\n",
+    "get access. Check the API docs section (next section), or the docstrings of\n",
+    "`UNFCCCApiReader` for details."
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     treelib
     requests
     pooch
+    pyarrow
 
 [options.extras_require]
 test = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     pandas
     treelib
     requests
+    pooch
 
 [options.extras_require]
 test = pytest

--- a/unfccc_di_api/__init__.py
+++ b/unfccc_di_api/__init__.py
@@ -12,6 +12,16 @@ __author__ = """Mika Pflüger"""
 __email__ = "mika.pflueger@pik-potsdam.de"
 __version__ = "3.0.2"
 
-from .unfccc_di_api import NoDataError, UNFCCCApiReader, UNFCCCSingleCategoryApiReader
+from .unfccc_di_api import (
+    NoDataError,
+    UNFCCCApiReader,
+    UNFCCCSingleCategoryApiReader,
+    ZenodoReader,
+)
 
-__all__ = ["UNFCCCApiReader", "UNFCCCSingleCategoryApiReader", "NoDataError"]
+__all__ = [
+    "UNFCCCApiReader",
+    "UNFCCCSingleCategoryApiReader",
+    "ZenodoReader",
+    "NoDataError",
+]

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -24,6 +24,13 @@ def reader(request):
         return ZenodoReader()
 
 
+def test_not_implemented(zenodo_reader):
+    with pytest.raises(NotImplementedError):
+        zenodo_reader.query(party_code="DEU", gases=["N2O"])
+    with pytest.raises(NotImplementedError):
+        zenodo_reader.query(party_code="DEU", normalize_gas_names=False)
+
+
 def test_non_annex_one(api_reader):
     ans = api_reader.non_annex_one_reader.query(party_codes=["MMR"])
 

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -85,8 +85,8 @@ class ZenodoReader:
 
     Attributes
     ----------
-    parties : pandas.DataFrame
-        All parties, with their ID, code, and full name.
+    parties : list[str]
+        All parties as a 3-letter iso code.
     """
 
     def __init__(

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -129,9 +129,15 @@ class ZenodoReader:
         gases : list of str, optional
             Limit the query to these gases. Accepts subscripts ("N₂O")
             as well as ASCII-strings ("N2O"). Default: query for all gases.
+            Note that anything else than the default is not yet implemented and raises
+            an error. Just request the whole dataset and filter using pandas' normal
+            functionality.
         normalize_gas_names : bool, optional
             If :obj:`True`, return gases as ASCII strings ("N2O").
             Else, return native UNFCCC notation ("N₂O"). Default: true.
+            Note that anything else than the default is not implemented and raises an
+            error. If you require unnormalized gas names, open an issue in the issue
+            tracker at github so we can understand your use case.
 
         Returns
         -------

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -290,7 +290,13 @@ class UNFCCCSingleCategoryApiReader:
         """
         self.base_url = base_url
 
-        parties_raw = self._get(f"parties/{party_category}")
+        try:
+            parties_raw = self._get(f"parties/{party_category}")
+        except requests.JSONDecodeError:
+            raise RuntimeError(
+                "Access to the UNFCCC API denied - see"
+                " https://github.com/pik-primap/unfccc_di_api#warning for solutions"
+            )
         parties_entries = []
         for entry in parties_raw:
             if entry["categoryCode"] == party_category and entry["name"] != "Groups":

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -17,8 +17,10 @@ limitations under the License.
 import itertools
 import logging
 import typing
+import zipfile
 
 import pandas as pd
+import pooch
 import requests
 import treelib
 
@@ -70,6 +72,76 @@ class NoDataError(KeyError):
             if optional_param is not None:
                 query += f" {key}={optional_param!r}"
         KeyError.__init__(self, f"Query returned no data for: {query}")
+
+
+class ZenodoReader:
+    """Provides simplified unified access to the data provided by the Flexible Query
+    API of the UNFCCC data access, via the dataset stored at zenodo.
+
+    Essentially gives you the same API as the UNFCCCApiReader, but without complications
+    due to the protection measures of the DI API. The advantage of using the
+    ZenodoReader is that it works reliably without special measures, the disadvantage
+    is that the data might be a bit older.
+
+    Attributes
+    ----------
+    parties : pandas.DataFrame
+        All parties, with their ID, code, and full name.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str = "doi:10.5281/zenodo.7432088/data-2022-12-13.zip",
+        known_hash: str = "md5:e7f660f88425078c75093d19841e5815",
+    ):
+        self._zipfile_path = pooch.retrieve(url=url, known_hash=known_hash)
+        self._zipfile = zipfile.ZipFile(self._zipfile_path)
+        self.parties = [
+            x.split("/")[-1][:3]
+            for x in self._zipfile.namelist()
+            if x.endswith(".parquet")
+        ]
+
+    def _get_party_data(self, *, party: str) -> pd.DataFrame:
+        fnames = [x for x in self._zipfile.namelist() if x.endswith(f"{party}.parquet")]
+        try:
+            fname = fnames[0]
+        except IndexError:
+            raise ValueError(f"Unknown party: {party}.")
+        with self._zipfile.open(fname) as fd:
+            return pd.read_parquet(fd)
+
+    def query(
+        self,
+        *,
+        party_code: str,
+        gases: typing.Optional[typing.Sequence[str]] = None,
+        normalize_gas_names: bool = True,
+    ) -> pd.DataFrame:
+        """Query the dataset for party data.
+
+        Parameters
+        ----------
+        party_code : str
+            ISO code of a party for which to query. For possible values, see
+            :py:attr:`~ZenodoReader.parties`.
+        gases : list of str, optional
+            Limit the query to these gases. Accepts subscripts ("N₂O")
+            as well as ASCII-strings ("N2O"). Default: query for all gases.
+        normalize_gas_names : bool, optional
+            If :obj:`True`, return gases as ASCII strings ("N2O").
+            Else, return native UNFCCC notation ("N₂O"). Default: true.
+
+        Returns
+        -------
+        pandas.DataFrame
+        """
+        if not normalize_gas_names:
+            raise NotImplementedError("Non-normalized gases not yet implemented")
+        if gases is not None:
+            raise NotImplementedError("Specific gas lists not yet implemented")
+        return self._get_party_data(party=party_code)
 
 
 class UNFCCCApiReader:

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -92,8 +92,8 @@ class ZenodoReader:
     def __init__(
         self,
         *,
-        url: str = "doi:10.5281/zenodo.7432088/data-2022-12-13.zip",
-        known_hash: str = "md5:e7f660f88425078c75093d19841e5815",
+        url: str = "doi:10.5281/zenodo.8159736/parquet-only.zip",
+        known_hash: str = "md5:95d98404f642ed2b684594abba8934ba",
     ):
         self._zipfile_path = pooch.retrieve(url=url, known_hash=known_hash)
         self._zipfile = zipfile.ZipFile(self._zipfile_path)


### PR DESCRIPTION
The ZenodoReader fetches data from zenodo instead of the UNFCCC API and presents a similar interface.