### PR TITLE
feat: use fake UserAgent to fool the API protection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     treelib
     requests
     pooch >= 1.8.0
+    fake-useragent
     pyarrow
 
 [options.extras_require]

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -48,7 +48,9 @@ def test_query(reader):
     assert len(res) > 0
 
 
-#@pytest.mark.skip(reason="UNFCCC reader not available")
+@pytest.mark.skipif(
+    "GITHUB_ACTIONS" not in os.environ, reason="UNFCCC reader not available"
+)
 def test_non_annex_one(api_reader):
     ans = api_reader.non_annex_one_reader.query(party_codes=["MMR"])
 
@@ -59,7 +61,9 @@ def test_non_annex_one(api_reader):
     assert len(ans) > 1
 
 
-#@pytest.mark.skip(reason="UNFCCC reader not available")
+@pytest.mark.skipif(
+    "GITHUB_ACTIONS" not in os.environ, reason="UNFCCC reader not available"
+)
 def test_annex_one(api_reader: UNFCCCApiReader):
     ans = api_reader.annex_one_reader.query(party_codes=["DEU"], gases=["N₂O"])
     assert len(ans) > 1
@@ -74,13 +78,17 @@ def test_unified(reader):
         reader.query(party_code="ASDF")
 
 
-#@pytest.mark.skip(reason="UNFCCC reader not available")
+@pytest.mark.skipif(
+    "GITHUB_ACTIONS" not in os.environ, reason="UNFCCC reader not available"
+)
 def test_unified_gases(api_reader: UNFCCCApiReader):
     ans = api_reader.query(party_code="DEU", gases=["N₂O"])
     assert len(ans) > 1
 
 
-#@pytest.mark.skip(reason="UNFCCC reader not available")
+@pytest.mark.skipif(
+    "GITHUB_ACTIONS" not in os.environ, reason="UNFCCC reader not available"
+)
 @pytest.mark.parametrize("normalize", [True, False])
 def test_unified_as_ascii(api_reader: UNFCCCApiReader, normalize: bool):
     # assert that using standardized string ('N2O' instead of "N₂O") works
@@ -91,7 +99,9 @@ def test_unified_as_ascii(api_reader: UNFCCCApiReader, normalize: bool):
     assert ans.gas.unique()[0] == ("N2O" if normalize else "N₂O")
 
 
-#@pytest.mark.skip(reason="UNFCCC reader not available")
+@pytest.mark.skipif(
+    "GITHUB_ACTIONS" not in os.environ, reason="UNFCCC reader not available"
+)
 @pytest.mark.parametrize("category_id", [9559, 9608])
 def test_category_filter(api_reader: UNFCCCApiReader, category_id):
     # this failed due to duplicate variableIds
@@ -102,7 +112,9 @@ def test_category_filter(api_reader: UNFCCCApiReader, category_id):
     assert len(df["category"].unique()) == 1
 
 
-#@pytest.mark.skip(reason="UNFCCC reader not available")
+@pytest.mark.skipif(
+    "GITHUB_ACTIONS" not in os.environ, reason="UNFCCC reader not available"
+)
 def test_no_data(api_reader: UNFCCCApiReader):
     with pytest.raises(unfccc_di_api.NoDataError):
         api_reader.annex_one_reader.query(party_codes=["FIN"], category_ids=[14817])

--- a/unfccc_di_api/tests/test_unfccc_di_api.py
+++ b/unfccc_di_api/tests/test_unfccc_di_api.py
@@ -48,7 +48,7 @@ def test_query(reader):
     assert len(res) > 0
 
 
-@pytest.mark.skip(reason="UNFCCC reader not available")
+#@pytest.mark.skip(reason="UNFCCC reader not available")
 def test_non_annex_one(api_reader):
     ans = api_reader.non_annex_one_reader.query(party_codes=["MMR"])
 
@@ -59,7 +59,7 @@ def test_non_annex_one(api_reader):
     assert len(ans) > 1
 
 
-@pytest.mark.skip(reason="UNFCCC reader not available")
+#@pytest.mark.skip(reason="UNFCCC reader not available")
 def test_annex_one(api_reader: UNFCCCApiReader):
     ans = api_reader.annex_one_reader.query(party_codes=["DEU"], gases=["N₂O"])
     assert len(ans) > 1
@@ -74,13 +74,13 @@ def test_unified(reader):
         reader.query(party_code="ASDF")
 
 
-@pytest.mark.skip(reason="UNFCCC reader not available")
+#@pytest.mark.skip(reason="UNFCCC reader not available")
 def test_unified_gases(api_reader: UNFCCCApiReader):
     ans = api_reader.query(party_code="DEU", gases=["N₂O"])
     assert len(ans) > 1
 
 
-@pytest.mark.skip(reason="UNFCCC reader not available")
+#@pytest.mark.skip(reason="UNFCCC reader not available")
 @pytest.mark.parametrize("normalize", [True, False])
 def test_unified_as_ascii(api_reader: UNFCCCApiReader, normalize: bool):
     # assert that using standardized string ('N2O' instead of "N₂O") works
@@ -91,7 +91,7 @@ def test_unified_as_ascii(api_reader: UNFCCCApiReader, normalize: bool):
     assert ans.gas.unique()[0] == ("N2O" if normalize else "N₂O")
 
 
-@pytest.mark.skip(reason="UNFCCC reader not available")
+#@pytest.mark.skip(reason="UNFCCC reader not available")
 @pytest.mark.parametrize("category_id", [9559, 9608])
 def test_category_filter(api_reader: UNFCCCApiReader, category_id):
     # this failed due to duplicate variableIds
@@ -102,7 +102,7 @@ def test_category_filter(api_reader: UNFCCCApiReader, category_id):
     assert len(df["category"].unique()) == 1
 
 
-@pytest.mark.skip(reason="UNFCCC reader not available")
+#@pytest.mark.skip(reason="UNFCCC reader not available")
 def test_no_data(api_reader: UNFCCCApiReader):
     with pytest.raises(unfccc_di_api.NoDataError):
         api_reader.annex_one_reader.query(party_codes=["FIN"], category_ids=[14817])

--- a/unfccc_di_api/unfccc_di_api.py
+++ b/unfccc_di_api/unfccc_di_api.py
@@ -23,6 +23,8 @@ import pandas as pd
 import pooch
 import requests
 import treelib
+from fake_useragent import UserAgent
+
 
 # mapping from gas as simple string to subscript-format used by UNFCCC DI API
 GAS_MAPPING = {
@@ -682,11 +684,11 @@ transparency-and-reporting/greenhouse-gas-data/data-interface-help#eq-7
         return tree
 
     def _get(self, component: str) -> typing.Any:
-        resp = requests.get(self.base_url + component)
+        resp = requests.get(self.base_url + component, headers={"User-Agent": UserAgent().random})
         resp.raise_for_status()
         return resp.json()
 
     def _post(self, component: str, json: dict) -> typing.List[dict]:
-        resp = requests.post(self.base_url + component, json=json)
+        resp = requests.post(self.base_url + component, json=json, headers={"User-Agent": UserAgent().random})
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
Testing out if the solution with the fake UserAgent made in https://github.com/pik-primap/unfccc_di_api/issues/74#issuecomment-1807993528 works for the API